### PR TITLE
Added new endpoint method GetAttachedContainerIDs

### DIFF
--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -116,6 +116,26 @@ func (endpoint *HNSEndpoint) IsAttached(vID string) (bool, error) {
 
 }
 
+// The following code is added for Calico.
+// Some CNI plugins does not clear endpoint properly when a pod has been teared down.
+// This function can be used to determine if an endpoint is active or not.
+type endpointAttachContainersInfo struct {
+	SharedContainers []string `json:",omitempty"`
+}
+
+func (endpoint *HNSEndpoint) GetAttachedContainerIDs() ([]string, error) {
+	attachInfo := endpointAttachContainersInfo{}
+	err := hnsCall("GET", "/endpoints/"+endpoint.Id, "", &attachInfo)
+
+	// Return false allows us to just return the err
+	if err != nil {
+		return []string{}, err
+	}
+
+	return attachInfo.SharedContainers, nil
+}
+// The above code is added for Calico.
+
 // Create Endpoint by sending EndpointRequest to HNS. TODO: Create a separate HNS interface to place all these methods
 func (endpoint *HNSEndpoint) Create() (*HNSEndpoint, error) {
 	operation := "Create"

--- a/internal/hns/hnsendpoint.go
+++ b/internal/hns/hnsendpoint.go
@@ -127,9 +127,8 @@ func (endpoint *HNSEndpoint) GetAttachedContainerIDs() ([]string, error) {
 	attachInfo := endpointAttachContainersInfo{}
 	err := hnsCall("GET", "/endpoints/"+endpoint.Id, "", &attachInfo)
 
-	// Return false allows us to just return the err
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
 	return attachInfo.SharedContainers, nil

--- a/internal/oc/exporter.go
+++ b/internal/oc/exporter.go
@@ -34,10 +34,14 @@ func (le *LogrusExporter) ExportSpan(s *trace.SpanData) {
 	baseEntry.Data["name"] = s.Name
 	baseEntry.Time = s.StartTime
 
-	level := logrus.InfoLevel
+	// Disabled for Calico.
+	//level := logrus.InfoLevel
 	if s.Status.Code != 0 {
-		level = logrus.ErrorLevel
+		// Disabled for Calico.
+		//level = logrus.ErrorLevel
 		baseEntry.Data[logrus.ErrorKey] = s.Status.Message
 	}
-	baseEntry.Log(level, "Span")
+
+	// Calico uses a forked version of logrus which does not support Entry.Log.
+	//baseEntry.Log(level, "Span")
 }


### PR DESCRIPTION
This PR added function `GetAttachedContainerIDs` and allow hcsshim to work with logrus package forked by projectcalico